### PR TITLE
fix: Remove empty UUID array parameter from BLE discover call

### DIFF
--- a/drivers/ruuvitag/driver.mjs
+++ b/drivers/ruuvitag/driver.mjs
@@ -145,7 +145,7 @@ class RuuviTag extends Homey.Driver {
             if (!scan_duration) scan_duration = 20;
 
             //scanning BLE devices
-            let foundDevices = await this.homey.ble.discover([], scan_duration * 1000);
+            let foundDevices = await this.homey.ble.discover(scan_duration * 1000);
 
             //sending bleAdv to ruuviTag
             for (const ruuvitag of this.ruuvitags) {


### PR DESCRIPTION
Fixed 'Invalid uuid - Expected a string with 4 or 8 characters' error by removing the empty array [] parameter from homey.ble.discover() call.

The Homey BLE SDK expects either no UUID filter parameter or an array of valid UUID strings (4 or 8 characters). Passing an empty array was causing validation to fail.

Fixes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)