### PR TITLE
fix: Remove deprecated BLE scan duration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Air quality monitor powered by wall adapter.
 
 ## BLE Driver Configuration
 
-Scan duration (how long Homey listens for BLE advertisements) and polling interval (time between scans) can be configured in app settings.
+Polling interval (time between scans) can be configured in app settings.
 
 Presence detection uses a configurable TTL system - number of scan attempts can be set per device in device settings.
 

--- a/README.txt
+++ b/README.txt
@@ -18,7 +18,7 @@ Ruuvi Air - Air quality monitor (powered by adapter)
 - No battery capability (powered device)
 
 BLE DRIVER CONFIGURATION:
-Scan duration (how long Homey listens for BLE advertisements) and polling interval (time between scans) can be configured in app settings. Number of scan attempts per device can be set in device settings for presence detection.
+Polling interval (time between scans) can be configured in app settings. Number of scan attempts per device can be set in device settings for presence detection.
 
 This apps allows integration of RuuviTag Gateway in Homey. You need first to activate API-key (bearer token) in Ruuvi Gateway ; see https://docs.ruuvi.com/gw-examples/polling-mode for more information. After that Homey will poll the latest data with timestamps from the gateway. 
 Gateway IP adress should be auto-detected ; you need to enter the bearer token in the next screen, and then choose Ruuvitag to add in Homey. 

--- a/drivers/ruuvitag/driver.mjs
+++ b/drivers/ruuvitag/driver.mjs
@@ -138,14 +138,12 @@ class RuuviTag extends Homey.Driver {
         while (this.polling) {
             console.log(`Refreshing BLE`);
             let polling_interval = this.homey.settings.get('polling_interval');
-            let scan_duration = this.homey.settings.get('scan_duration');
 
-            //default value for polling and scan
+            //default value for polling
             if (!polling_interval) polling_interval = 60;
-            if (!scan_duration) scan_duration = 20;
 
             //scanning BLE devices
-            let foundDevices = await this.homey.ble.discover(scan_duration * 1000);
+            let foundDevices = await this.homey.ble.discover();
 
             //sending bleAdv to ruuviTag
             for (const ruuvitag of this.ruuvitags) {

--- a/settings/index.html
+++ b/settings/index.html
@@ -14,10 +14,6 @@
         <legend>Settings</legend>
 
         <div class="field row">
-            <label for="scan">Scan duration (in seconds)</label>
-            <input id="scan" type="number" value="" />
-        </div>
-        <div class="field row">
             <label for="poll">Polling interval (in seconds)</label>
             <input id="poll" type="number" value="" />
         </div>
@@ -33,14 +29,8 @@
 	        // Tell Homey we're ready to be displayed
             Homey.ready();
 
-            var scanElement = document.getElementById('scan');
             var pollElement = document.getElementById('poll');
             var saveElement = document.getElementById('save');
-
-            Homey.get('scan_duration', function( err, scan ) {
-	           if( err ) return Homey.alert( err );
-                scanElement.value = scan ? scan : 20;
-	        });
 
             Homey.get('polling_interval', function( err, poll ) {
 	           if( err ) return Homey.alert( err );
@@ -49,15 +39,11 @@
 
 	        saveElement.addEventListener('click', function(e) {
 
-                if (scanElement.value < 1 || scanElement.value >= 30 || pollElement.value < 10 || pollElement.value > 900) {
-                    scanElement.value = 20; 
+                if (pollElement.value < 10 || pollElement.value > 900) {
                     pollElement.value = 60;
-                    Homey.alert("scan duration must be between 1 and 30 ; polling interval between 10 and 900");
+                    Homey.alert("Polling interval must be between 10 and 900");
                 }
                 else {
-                    Homey.set('scan_duration', scanElement.value, function (err) {
-                        if (err) return Homey.alert(err);
-                    });
                     Homey.set('polling_interval', pollElement.value, function (err) {
                         if (err) return Homey.alert(err);
                     });


### PR DESCRIPTION
The scan_duration parameter for ble.discover() is no longer needed.
Removed it from the driver code, settings UI, and documentation.